### PR TITLE
Added .travis.yml for using Travis-CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "nettle"]
 	path = firmware/nettle
-	url = ../nettle.git
+	url = https://github.com/nthdimtech/nettle.git
 [submodule "crosstool-ng"]
 	path = firmware/crosstool-ng
-	url = ../crosstool-ng.git
+	url = https://github.com/nthdimtech/crosstool-ng.git
 [submodule "signet-base"]
 	path = signet-base
-	url = ../signet-base
+	url = https://github.com/nthdimtech/signet-base
 [submodule "keepassx"]
 	path = keepassx
-	url = ../keepassx.git
+	url = https://github.com/nthdimtech/keepassx.git
 [submodule "qtcsv"]
 	path = qtcsv
 	url = https://github.com/iamantony/qtcsv.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,18 @@ compiler:
   - gcc
   
 os:
-  - linux
+  - osx
 
 before_install:
   - echo $LANG
   - echo $LC_ALL
   - git submodule update --init
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install qt5-default libqt5websockets5-dev libqt5x11extras5-dev libgcrypt20-dev zlib1g-dev libx11-dev; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install qt5 libgcrypt libgpg-error zlib; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install qt5-default qtdeclarative5-dev libqt5x11extras5-dev libgcrypt20-dev zlib1g-dev libx11-dev qtbase5-dev; fi
+  # using  brew instal libgcrypt got Error: libgcrypt 1.8.1 is already installed, This formula is keg-only, which means it was not symlinked into /usr/local,
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew upgrade libgcrypt && brew install qt5 libgpg-error zlib; fi
 script:
-  - if [ $TRAVIS_OS_NAME == linux ]; then qmake client/client.pro && make; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then /usr/local/opt/qt5/bin/qmake client/client.pro && /usr/local/opt/qt5/bin/qmake client/client.pro; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then /usr/local/opt/qt5/bin/qmake client/client.pro && /usr/local/opt/qt5/bin/qmake client/client.pro && make; fi
 
 notifications:
   email:
   - niklaus.giger@member.fsf.org
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,23 @@ compiler:
   
 os:
   - osx
+  - linux
 
 before_install:
   - echo $LANG
   - echo $LC_ALL
   - git submodule update --init
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install qt5-default qtdeclarative5-dev libqt5x11extras5-dev libgcrypt20-dev zlib1g-dev libx11-dev qtbase5-dev; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install libqt5websockets5-dev qt5-default qtdeclarative5-dev libqt5x11extras5-dev libgcrypt20-dev zlib1g-dev libx11-dev qtbase5-dev; fi
   # using  brew instal libgcrypt got Error: libgcrypt 1.8.1 is already installed, This formula is keg-only, which means it was not symlinked into /usr/local,
   - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew upgrade libgcrypt && brew install qt5 libgpg-error zlib; fi
 script:
-  - if [ $TRAVIS_OS_NAME == osx ]; then /usr/local/opt/qt5/bin/qmake client/client.pro && /usr/local/opt/qt5/bin/qmake client/client.pro && make; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then qmake client/client.pro && make; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then /usr/local/opt/qt5/bin/qmake client/client.pro && make; fi
 
 notifications:
   email:
   - niklaus.giger@member.fsf.org
+
+matrix:
+  allow_failures:
+    - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+---
+language: cpp
+
+sudo: required
+
+compiler:
+  - gcc
+  
+os:
+  - linux
+
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+  - git submodule update --init
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install qt5-default libqt5websockets5-dev libqt5x11extras5-dev libgcrypt20-dev zlib1g-dev libx11-dev; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install qt5 libgcrypt libgpg-error zlib; fi
+script:
+  - if [ $TRAVIS_OS_NAME == linux ]; then qmake client/client.pro && make; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then /usr/local/opt/qt5/bin/qmake client/client.pro && /usr/local/opt/qt5/bin/qmake client/client.pro; fi
+
+notifications:
+  email:
+  - niklaus.giger@member.fsf.org
+


### PR DESCRIPTION
Hi
I am a big fan of using Continuos integration and one my favorite tools is Travis CI.

Here I attached the configuration files to compile the signet-desktop on
* linux
* macosx
The linux build currently fails (but is marked as being ignored), as travis-ci uses Ubuntu trusty where there is no libqt5websockets5-dev package.
If you pull this branch, please update afterwars the email-address in .travis.yml to your email (or remove the section), as I do not want receive mails.