### PR TITLE
Allow search to match not only at start of title

### DIFF
--- a/client/esdb/esdb.cpp
+++ b/client/esdb/esdb.cpp
@@ -147,7 +147,9 @@ int esdbEntry::matchQuality(const QString &search) const
 	QString title = getTitle();
 	int quality = 0;
 	if (title.startsWith(search, Qt::CaseInsensitive)) {
-		quality++;
+		quality += 2;
+	}else if(title.contains(search, Qt::CaseInsensitive)) {
+		quality += 1;
 	}
 	return quality;
 }

--- a/client/signetapplication.cpp
+++ b/client/signetapplication.cpp
@@ -234,6 +234,7 @@ void SignetApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
 			}
 			m_main_window->raise();
+			m_main_window->activateWindow();
 		} else {
 			if (m_main_window->isMinimized()) {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
@@ -241,6 +242,7 @@ void SignetApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
 			} else {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowActive) | Qt::WindowMinimized);
 			}
+                        m_main_window->hide();
 		}
 		break;
 	default:

--- a/client/signetapplication.cpp
+++ b/client/signetapplication.cpp
@@ -234,7 +234,6 @@ void SignetApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
 			}
 			m_main_window->raise();
-			m_main_window->activateWindow();
 		} else {
 			if (m_main_window->isMinimized()) {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
@@ -242,7 +241,6 @@ void SignetApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
 			} else {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowActive) | Qt::WindowMinimized);
 			}
-                        m_main_window->hide();
 		}
 		break;
 	default:


### PR DESCRIPTION
Matches at the start will have a higher priority than others.

This is a first step for issue #43 

See also: 
Signet-discuss mailing list
> Re: [Signet-discuss] Signet Client | Possibility execute full text search in `Account name`
msgid 7cc4af1a-dec9-4ba7-fb1a-f077fedd117b@nthdimtech.com on 2018-02-04