### PR TITLE
Matches at the start will have a higher priority than others.

### DIFF
--- a/client/esdb/esdb.cpp
+++ b/client/esdb/esdb.cpp
@@ -147,7 +147,9 @@ int esdbEntry::matchQuality(const QString &search) const
 	QString title = getTitle();
 	int quality = 0;
 	if (title.startsWith(search, Qt::CaseInsensitive)) {
-		quality++;
+		quality += 2;
+	}else if(title.contains(search, Qt::CaseInsensitive)) {
+		quality += 1;
 	}
 	return quality;
 }


### PR DESCRIPTION
This is a first step for issue #43

See also:
Signet-discuss mailing list
> Re: [Signet-discuss] Signet Client | Possibility execute full text search in `Account name`
msgid 7cc4af1a-dec9-4ba7-fb1a-f077fedd117b@nthdimtech.com on 2018-02-04

Sorry for the previous #53 PR mess, went through git hell ;)