### PR TITLE
Activate and hide properly when clicking on the tray icon while using i3wm

### DIFF
--- a/client/signetapplication.cpp
+++ b/client/signetapplication.cpp
@@ -234,12 +234,15 @@ void SignetApplication::trayActivated(QSystemTrayIcon::ActivationReason reason)
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
 			}
 			m_main_window->raise();
+			m_main_window->activateWindow();
 		} else {
 			if (m_main_window->isMinimized()) {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
 				m_main_window->raise();
+				m_main_window->activateWindow();
 			} else {
 				m_main_window->setWindowState((m_main_window->windowState() & ~Qt::WindowActive) | Qt::WindowMinimized);
+				m_main_window->hide();
 			}
 		}
 		break;


### PR DESCRIPTION
When using i3wm the focus would disappear but the window stay or the focus
not be returned properly.

Tested with icewm and i3wm on Linux.