### PR TITLE
Add --start-in-systray: "Start application minimized in the system tray"

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
 		box->deleteLater();
 	}
 
+#ifdef Q_OS_UNIX
 	QCommandLineParser parser;
 	QCommandLineOption startInTrayOption("start-in-systray", "Start application minimized in the system tray");
 
@@ -59,7 +60,12 @@ int main(int argc, char **argv)
         parser.addHelpOption();
 	parser.process(a);
 
-	a.init(parser.isSet(startInTrayOption));
+        bool startInTray = parser.isSet(startInTrayOption);
+#else
+        bool startInTray = false;
+#endif
+
+	a.init(startInTray);
 	a.exec();
 	return 0;
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -3,6 +3,7 @@
 #include "crypto/Crypto.h"
 
 #include <QThread>
+#include <QCommandLineParser>
 
 int main(int argc, char **argv)
 {
@@ -50,7 +51,15 @@ int main(int argc, char **argv)
 		}
 		box->deleteLater();
 	}
-	a.init();
+
+	QCommandLineParser parser;
+	QCommandLineOption startInTrayOption("start-in-systray", "Start application minimized in the system tray");
+
+	parser.addOption(startInTrayOption);
+        parser.addHelpOption();
+	parser.process(a);
+
+	a.init(parser.isSet(startInTrayOption));
 	a.exec();
 	return 0;
 }

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -221,6 +221,13 @@ MainWindow::MainWindow(QWidget *parent) :
 	m_backupAction->setVisible(false);
 	m_restoreAction->setVisible(false);
 	enterDeviceState(STATE_NEVER_SHOWN);
+#ifdef Q_OS_UNIX
+	enterDeviceState(STATE_CONNECTING);
+	int rc = signetdev_open_connection();
+	if (rc == 0) {
+		deviceOpened();
+	}
+#endif
 }
 
 QString MainWindow::csvQuote(const QString &s)
@@ -727,18 +734,18 @@ void MainWindow::signetdevStartupResp(signetdevCmdRespInfo info, signetdev_start
 
 void MainWindow::showEvent(QShowEvent *event)
 {
+#ifdef _WIN32
 	if (!event->spontaneous()) {
 		if (m_deviceState == STATE_NEVER_SHOWN) {
 			enterDeviceState(STATE_CONNECTING);
-#ifdef _WIN32
 			signetdev_win32_set_window_handle((HANDLE)winId());
-#endif
 			int rc = signetdev_open_connection();
 			if (rc == 0) {
 				deviceOpened();
 			}
 		}
 	}
+#endif
 }
 
 

--- a/client/signetapplication.cpp
+++ b/client/signetapplication.cpp
@@ -201,13 +201,7 @@ void SignetApplication::init(bool startInTray)
 	m_systray.setIcon(app_icon);
 
 	m_systray.show();
-	if (startInTray) {
-		/* FIXME: if we just hide() the window a button push will not show it
-		 *        but with showMinimized() it will briefly flash in the taskbar
-		 */
-		m_main_window->showMinimized();
-		m_main_window->hide();
-	} else {
+	if (!startInTray) {
 		m_main_window->show();
 	}
 }

--- a/client/signetapplication.cpp
+++ b/client/signetapplication.cpp
@@ -169,7 +169,7 @@ void SignetApplication::commandRespS(void *cb_param, void *cmd_user_param, int c
 	}
 }
 
-void SignetApplication::init()
+void SignetApplication::init(bool startInTray)
 {
 	signetdev_initialize_api();
 	signetdev_set_device_opened_cb(deviceOpenedS, this);
@@ -201,7 +201,15 @@ void SignetApplication::init()
 	m_systray.setIcon(app_icon);
 
 	m_systray.show();
-	m_main_window->show();
+	if (startInTray) {
+		/* FIXME: if we just hide() the window a button push will not show it
+		 *        but with showMinimized() it will briefly flash in the taskbar
+		 */
+		m_main_window->showMinimized();
+		m_main_window->hide();
+	} else {
+		m_main_window->show();
+	}
 }
 
 QMessageBox *SignetApplication::messageBoxError(QMessageBox::Icon icon, const QString &title, const QString &text, QWidget *parent)

--- a/client/signetapplication.h
+++ b/client/signetapplication.h
@@ -36,7 +36,7 @@ class SignetApplication : public QtSingleApplication
 	static SignetApplication *g_singleton;
 public:
 	SignetApplication(int &argc, char **argv);
-	void init();
+	void init(bool startInTray);
 	static QMessageBox *messageBoxError(QMessageBox::Icon icon, const QString &title, const QString &text, QWidget *parent);
 	static SignetApplication *get()
 	{


### PR DESCRIPTION
The aim of this option is to provide a way to start the Signet desktop
client e.g. during login and not have the user bothered by the window
popping up.

When needed the user shall display the window by either pressing the button
on the device, left-clicking the systray icon or chosing "Open" from the
systray icon right-click menu.

FIXME:
Currently showMinimized() is called before hide() to be able to make
the window visible when user presses the button on the device.
This introduces a flicker in the task bar since the window is for a brief
moment shown there as minimized before it is hidden.
It would be better to use setVisible() or showNormal() where the button
press is handled and just hide() in SignetApplication::init.

I could not yet figure out where the code is that handles a button press on the device to activate the main window; any pointer appreciated.