### PR TITLE
Fix compiler warning "unused event" in MainWindow::showEvent() for non-_WIN32

### DIFF
--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -745,6 +745,8 @@ void MainWindow::showEvent(QShowEvent *event)
 			}
 		}
 	}
+#else
+        Q_UNUSED(event)
 #endif
 }
 


### PR DESCRIPTION
Due to the move of connection code for Q_OS_UNIX to the MainWindow
constructor there is nothing left to do for it in showEvent() and the
compiler warns about the unused event variable.