### PR TITLE
Move non-persistent settings to file in cache directory

### DIFF
--- a/client/desktop/localcache.h
+++ b/client/desktop/localcache.h
@@ -1,0 +1,13 @@
+#ifndef LOCALCACHE_H
+#define LOCALCACHE_H
+
+#include <QByteArray>
+#include <QDateTime>
+
+struct localCache {
+	QDateTime lastRemoveableBackup;
+	QDateTime lastUpdatePrompt;
+	QByteArray windowGeometry;
+};
+
+#endif // LOCALCACHE_H

--- a/client/desktop/localsettings.h
+++ b/client/desktop/localsettings.h
@@ -4,7 +4,6 @@
 #include <QVector>
 #include <QMap>
 #include <QString>
-#include <QDateTime>
 
 extern "C" {
 #include "signetdev/host/signetdev.h"
@@ -21,11 +20,8 @@ struct localSettings {
 	QString removableBackupPath;
 	QString removableBackupVolume;
 	int removableBackupInterval;
-	QDateTime lastRemoveableBackup;
-	QDateTime lastUpdatePrompt;
 	QMap<QString, keyboardLayout> keyboardLayouts;
 	QString activeKeyboardLayout;
-	QByteArray windowGeometry;
 	bool minimizeToTray;
 };
 

--- a/client/desktop/mainwindow.h
+++ b/client/desktop/mainwindow.h
@@ -13,6 +13,7 @@
 #include "esdbmodel.h"
 #include "systemtray.h"
 #include "signetapplication.h"
+#include "localcache.h"
 #include "localsettings.h"
 #include "esdbgenericmodule.h"
 
@@ -69,6 +70,7 @@ class MainWindow : public QMainWindow
 	QString m_dbFilename;
 	QString m_backupDirectory;
 	localSettings m_settings;
+	localCache m_cache;
 	esdbTypeModule *m_genericTypeModule;
 	esdbTypeModule *m_accountTypeModule;
 	esdbTypeModule *m_bookmarkTypeModule;
@@ -187,7 +189,11 @@ private:
 #endif
 
 	void sendFirmwareWriteCmd();
+	void loadPersistentSettings();
+	void loadCachedSettings();
 	void loadSettings();
+	void savePersistentSettings();
+	void saveCachedSettings();
 	void saveSettings();
 	void settingsChanged();
 	void autoBackupCheck();


### PR DESCRIPTION
`lastRemoveableBackup`, `lastUpdatePrompt`, and `windowGeometry` are more like
cached variables than proper settings since they may change at each
start of the program.

Moved them to a separate struct, `localCache` and split the `saveSettings()`
and `loadSettings()` functions into two, one for `localSettings` and one for
`localCache`.

My motivation for this is due to the fact that I manage my dotfiles using git. Every time I start signet, one or more of the 3 options I move has changed so I see the file as changed but it makes no sense to commit it.